### PR TITLE
replies and forward

### DIFF
--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -94,11 +94,12 @@ class Wormhole(commands.Cog):
         )
 
         if message.reference and message.reference.type == MessageReferenceType.reply:
-            formatted_message = f"> {message.reference.cached_message.content.replace("\n", "\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
+            msg = message.reference.cached_message.content.replace("\n", "\n> ")
+            formatted_message = f"> {msg if message.reference.cached_message else 'Unknown'}\n{formatted_message}"
         elif (
             message.reference and message.reference.type == MessageReferenceType.forward
         ):
-            formatted_message = f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"
+            formatted_message = f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else 'Unknown forwarded message'}```"
         return formatted_message
 
     async def _set_slowmode(

--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -3,7 +3,7 @@ import unicodedata
 from typing import Optional
 
 import discord
-from discord import app_commands
+from discord import app_commands, MessageReferenceType
 from discord.ext import commands, tasks
 
 from pie import check, i18n, logger, storage, utils
@@ -92,6 +92,16 @@ class Wormhole(commands.Cog):
         formatted_message = (
             f"**{guild_display} {message.author.name}:** {message.content}"
         )
+
+        if message.reference and message.reference.type == MessageReferenceType.reply:
+            formatted_message = (
+                f"> {message.reference.cached_message.content.replace("\n","\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
+            )
+            print(message.reference.cached_message.content if message.reference.cached_message else "Unknown")
+        elif message.reference and message.reference.type == MessageReferenceType.forward:
+            formatted_message = (
+                f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"
+            )
         return formatted_message
 
     async def _set_slowmode(

--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -3,11 +3,12 @@ import unicodedata
 from typing import Optional
 
 import discord
-from discord import app_commands, MessageReferenceType
+from discord import MessageReferenceType, app_commands
 from discord.ext import commands, tasks
 
 from pie import check, i18n, logger, storage, utils
 from pie.bot import Strawberry
+
 from .database import (  # Local database model for managing wormhole channels
     WormholeChannel,
 )
@@ -95,7 +96,7 @@ class Wormhole(commands.Cog):
         if message.reference and message.reference.type == MessageReferenceType.reply:
             formatted_message = f"> {message.reference.cached_message.content.replace("\n", "\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
         elif (
-                message.reference and message.reference.type == MessageReferenceType.forward
+            message.reference and message.reference.type == MessageReferenceType.forward
         ):
             formatted_message = f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"
         return formatted_message

--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -97,7 +97,6 @@ class Wormhole(commands.Cog):
             formatted_message = (
                 f"> {message.reference.cached_message.content.replace("\n","\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
             )
-            print(message.reference.cached_message.content if message.reference.cached_message else "Unknown")
         elif message.reference and message.reference.type == MessageReferenceType.forward:
             formatted_message = (
                 f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"

--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -8,7 +8,6 @@ from discord.ext import commands, tasks
 
 from pie import check, i18n, logger, storage, utils
 from pie.bot import Strawberry
-
 from .database import (  # Local database model for managing wormhole channels
     WormholeChannel,
 )
@@ -94,13 +93,11 @@ class Wormhole(commands.Cog):
         )
 
         if message.reference and message.reference.type == MessageReferenceType.reply:
-            formatted_message = (
-                f"> {message.reference.cached_message.content.replace("\n","\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
-            )
-        elif message.reference and message.reference.type == MessageReferenceType.forward:
-            formatted_message = (
-                f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"
-            )
+            formatted_message = f"> {message.reference.cached_message.content.replace("\n", "\n> ") if message.reference.cached_message else "Unknown"}\n{formatted_message}"
+        elif (
+                message.reference and message.reference.type == MessageReferenceType.forward
+        ):
+            formatted_message = f"**{guild_display} {message.author.name}:** Forwarded\n```{message.reference.cached_message.content if message.reference.cached_message else "Unknown forwarded message"}```"
         return formatted_message
 
     async def _set_slowmode(

--- a/wormhole/module.py
+++ b/wormhole/module.py
@@ -94,8 +94,13 @@ class Wormhole(commands.Cog):
         )
 
         if message.reference and message.reference.type == MessageReferenceType.reply:
-            msg = message.reference.cached_message.content.replace("\n", "\n> ")
-            formatted_message = f"> {msg if message.reference.cached_message else 'Unknown'}\n{formatted_message}"
+            msg = (
+                message.reference.cached_message.content.replace("\n", "\n> ")
+                if message.reference.cached_message
+                and message.reference.cached_message.content
+                else "Unknown reference message"
+            )
+            formatted_message = f"> {msg}\n{formatted_message}"
         elif (
             message.reference and message.reference.type == MessageReferenceType.forward
         ):


### PR DESCRIPTION
Replies look like this
<img width="189" height="113" alt="image" src="https://github.com/user-attachments/assets/5190e431-a5e8-47ba-ac1e-a221a9e3f36a" />
The example is a nested reply (reply to reply to reply to original message). The latest mesage is the most bottom one.

Forward looks like this
<img width="280" height="124" alt="image" src="https://github.com/user-attachments/assets/66639840-0545-4356-b1af-eee6d4df9e4b" />
If a user adds a comment to forward, Discord sends it as a separate message, so it might arrive in reverse order; it can't be fixed.